### PR TITLE
Implement rewrite of netmap vmxnet3 RX/TX routines

### DIFF
--- a/drivers/net/vmxnet3/vmxnet3_drv.c
+++ b/drivers/net/vmxnet3/vmxnet3_drv.c
@@ -309,7 +309,7 @@ static u32 get_bitfield32(const __le32 *bitfield, u32 pos, u32 size)
 
 
 #if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE) || defined(DEV_NETMAP)
-#include "if_vmxnet3_netmap.h"
+#include "if_vmxnet3_netmap_v2.h"
 #endif
 
 
@@ -375,10 +375,9 @@ vmxnet3_tq_tx_complete(struct vmxnet3_tx_queue *tq,
 #ifdef DEV_NETMAP
 	struct net_device *netdev = adapter->netdev;
 
-	if (netmap_tx_irq(netdev, 0) != NM_IRQ_PASS)
+	if (netmap_tx_irq(netdev, tq - adapter->tx_queue) != NM_IRQ_PASS)
 		return 0;
 #endif
-		
 
 	gdesc = tq->comp_ring.base + tq->comp_ring.next2proc;
 	while (VMXNET3_TCD_GET_GEN(&gdesc->tcd) == tq->comp_ring.gen) {
@@ -504,6 +503,10 @@ vmxnet3_tq_init(struct vmxnet3_tx_queue *tq,
 	memset(tq->buf_info, 0, sizeof(tq->buf_info[0]) * tq->tx_ring.size);
 	for (i = 0; i < tq->tx_ring.size; i++)
 		tq->buf_info[i].map_type = VMXNET3_MAP_NONE;
+
+#ifdef DEV_NETMAP
+	vmxnet3_netmap_tq_config_tx_buf(tq, adapter);
+#endif /* DEV_NETMAP */
 
 	/* stats are not reset */
 }
@@ -1286,8 +1289,8 @@ vmxnet3_rq_rx_complete(struct vmxnet3_rx_queue *rq,
 #ifdef DEV_NETMAP
 	u_int total_packets = 0;
 	struct net_device *netdev = adapter->netdev;
-	
-	if (netmap_rx_irq(netdev, 0, &total_packets) != NM_IRQ_PASS)
+
+	if (netmap_rx_irq(netdev, rq - adapter->rx_queue, &total_packets) != NM_IRQ_PASS)
 		return 1;
 #endif /* DEV_NETMAP */
 
@@ -1714,12 +1717,18 @@ vmxnet3_rq_init(struct vmxnet3_rx_queue *rq,
 		       sizeof(struct Vmxnet3_RxDesc));
 		rq->rx_ring[i].gen = VMXNET3_INIT_GEN;
 	}
-	if (vmxnet3_rq_alloc_rx_buf(rq, 0, rq->rx_ring[0].size - 1,
-				    adapter) == 0) {
-		/* at least has 1 rx buffer for the 1st ring */
-		return -ENOMEM;
+#ifdef DEV_NETMAP
+	if (!vmxnet3_netmap_rq_config_rx_buf(rq, adapter)) {
+#endif /* DEV_NETMAP */
+		if (vmxnet3_rq_alloc_rx_buf(rq, 0, rq->rx_ring[0].size - 1,
+					    adapter) == 0) {
+			/* at least has 1 rx buffer for the 1st ring */
+			return -ENOMEM;
+		}
+		vmxnet3_rq_alloc_rx_buf(rq, 1, rq->rx_ring[1].size - 1, adapter);
+#ifdef DEV_NETMAP
 	}
-	vmxnet3_rq_alloc_rx_buf(rq, 1, rq->rx_ring[1].size - 1, adapter);
+#endif /* DEV_NETMAP */
 
 	/* reset the comp ring */
 	rq->comp_ring.next2proc = 0;
@@ -1823,7 +1832,11 @@ vmxnet3_rq_create_all(struct vmxnet3_adapter *adapter)
 {
 	int i, err = 0;
 
+#ifdef DEV_NETMAP
+	vmxnet3_netmap_set_rxdataring_enabled(adapter);
+#else
 	adapter->rxdataring_enabled = VMXNET3_VERSION_GE_3(adapter);
+#endif /* DEV_NETMAP */
 
 	for (i = 0; i < adapter->num_rx_queues; i++) {
 		err = vmxnet3_rq_create(&adapter->rx_queue[i], adapter);
@@ -2561,15 +2574,16 @@ vmxnet3_activate_dev(struct vmxnet3_adapter *adapter)
 
 #ifdef DEV_NETMAP
 	vmxnet3_netmap_init_buffers(adapter);
-#endif /* DEV_NETMAP */    
+#endif /* DEV_NETMAP */
 
-	vmxnet3_tq_init_all(adapter);
 	err = vmxnet3_rq_init_all(adapter);
 	if (err) {
 		netdev_err(adapter->netdev,
 			   "Failed to init rx queue error %d\n", err);
 		goto rq_err;
 	}
+
+	vmxnet3_tq_init_all(adapter);
 
 	err = vmxnet3_request_irqs(adapter);
 	if (err) {
@@ -2858,7 +2872,12 @@ vmxnet3_create_queues(struct vmxnet3_adapter *adapter, u32 tx_ring_size,
 	adapter->rx_queue[0].rx_ring[1].size = rx_ring2_size;
 	vmxnet3_adjust_rx_ring_size(adapter);
 
+#ifdef DEV_NETMAP
+	vmxnet3_netmap_set_rxdataring_enabled(adapter);
+#else
 	adapter->rxdataring_enabled = VMXNET3_VERSION_GE_3(adapter);
+#endif /* DEV_NETMAP */
+
 	for (i = 0; i < adapter->num_rx_queues; i++) {
 		struct vmxnet3_rx_queue *rq = &adapter->rx_queue[i];
 		/* qid and qid2 for rx queues will be assigned later when num
@@ -3489,10 +3508,10 @@ vmxnet3_probe_device(struct pci_dev *pdev,
 		goto err_register;
 	}
 
-    
+
 #ifdef DEV_NETMAP
 	vmxnet3_netmap_attach(adapter);
-#endif /* DEV_NETMAP */    
+#endif /* DEV_NETMAP */
 
 	vmxnet3_check_link(adapter, false);
 	return 0;
@@ -3553,7 +3572,7 @@ vmxnet3_remove_device(struct pci_dev *pdev)
 
 #ifdef DEV_NETMAP
 	vmxnet3_netmap_detach(netdev);
-#endif /* DEV_NETMAP */    
+#endif /* DEV_NETMAP */
 
 	vmxnet3_free_intr_resources(adapter);
 	vmxnet3_free_pci_resources(adapter);


### PR DESCRIPTION
These are the changes to the vmxnet3 driver "vanilla" file(s) for the implementation of the vmxnet3 netmap driver with the improved RX/TX routines.