### PR TITLE
stmmac: add netmap entry point functions

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -84,7 +84,7 @@ static int tc = TC_DEFAULT;
 module_param(tc, int, S_IRUGO | S_IWUSR);
 MODULE_PARM_DESC(tc, "DMA threshold control value");
 
-#define	DEFAULT_BUFSIZE	1536
+#define	DEFAULT_BUFSIZE	BUF_SIZE_4KiB
 static int buf_sz = DEFAULT_BUFSIZE;
 module_param(buf_sz, int, S_IRUGO | S_IWUSR);
 MODULE_PARM_DESC(buf_sz, "DMA buffer size");
@@ -116,6 +116,10 @@ static void stmmac_exit_fs(struct net_device *dev);
 #endif
 
 #define STMMAC_COAL_TIMER(x) (jiffies + usecs_to_jiffies(x))
+
+#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
+#include <if_stmmac_netmap_linux.h>
+#endif
 
 /**
  * stmmac_verify_args - verify the driver parameters.
@@ -560,7 +564,7 @@ static int stmmac_hwtstamp_ioctl(struct net_device *dev, struct ifreq *ifr)
 			if (priv->plat->has_gmac4)
 				snap_type_sel = PTP_GMAC4_TCR_SNAPTYPSEL_1;
 			else
-				snap_type_sel = PTP_TCR_SNAPTYPSEL_1;
+				snap_type_sel = 0xFFFFFFFF & PTP_TCR_SNAPTYPSEL_1;
 
 			ptp_over_ipv4_udp = PTP_TCR_TSIPV4ENA;
 			ptp_over_ipv6_udp = PTP_TCR_TSIPV6ENA;
@@ -595,7 +599,7 @@ static int stmmac_hwtstamp_ioctl(struct net_device *dev, struct ifreq *ifr)
 			if (priv->plat->has_gmac4)
 				snap_type_sel = PTP_GMAC4_TCR_SNAPTYPSEL_1;
 			else
-				snap_type_sel = PTP_TCR_SNAPTYPSEL_1;
+				snap_type_sel = 0xFFFFFFFF & PTP_TCR_SNAPTYPSEL_1;
 
 			ptp_over_ipv4_udp = PTP_TCR_TSIPV4ENA;
 			ptp_over_ipv6_udp = PTP_TCR_TSIPV6ENA;
@@ -632,7 +636,7 @@ static int stmmac_hwtstamp_ioctl(struct net_device *dev, struct ifreq *ifr)
 			if (priv->plat->has_gmac4)
 				snap_type_sel = PTP_GMAC4_TCR_SNAPTYPSEL_1;
 			else
-				snap_type_sel = PTP_TCR_SNAPTYPSEL_1;
+				snap_type_sel = 0xFFFFFFFF & PTP_TCR_SNAPTYPSEL_1;
 
 			ptp_over_ipv4_udp = PTP_TCR_TSIPV4ENA;
 			ptp_over_ipv6_udp = PTP_TCR_TSIPV6ENA;
@@ -1231,6 +1235,22 @@ static int init_dma_rx_desc_rings(struct net_device *dev, gfp_t flags)
 	netif_dbg(priv, probe, priv->dev,
 		  "SKB addresses:\nskb\t\tskb data\tdma data\n");
 
+#ifdef DEV_NETMAP
+	if (stmmac_netmap_rx_init(priv)) {
+		priv->cur_rx = 0;
+		priv->dirty_rx = 1;
+		buf_sz = bfsize;
+
+		if (stmmac_netmap_tx_init(priv)) {
+			priv->dirty_tx = 0;
+			priv->cur_tx = 0;
+			netdev_reset_queue(priv->dev);
+			return 0;
+		}
+	}
+
+#endif /* DEV_NETMAP */
+
 	for (queue = 0; queue < rx_count; queue++) {
 		struct stmmac_rx_queue *rx_q = &priv->rx_queue[queue];
 
@@ -1801,6 +1821,11 @@ static void stmmac_tx_clean(struct stmmac_priv *priv, u32 queue)
 	struct stmmac_tx_queue *tx_q = &priv->tx_queue[queue];
 	unsigned int bytes_compl = 0, pkts_compl = 0;
 	unsigned int entry = tx_q->dirty_tx;
+
+#ifdef DEV_NETMAP
+	if (netmap_tx_irq(priv->dev, 0))
+		return;
+#endif /* DEV_NETMAP */
 
 	netif_tx_lock(priv->dev);
 
@@ -2509,7 +2534,7 @@ static int stmmac_hw_setup(struct net_device *dev, bool init_ptp)
 	}
 
 	if (priv->hw->pcs && priv->hw->mac->pcs_ctrl_ane)
-		priv->hw->mac->pcs_ctrl_ane(priv->hw, 1, priv->hw->ps, 0);
+		priv->hw->mac->pcs_ctrl_ane((void __iomem *)priv->hw, 1, priv->hw->ps, 0);
 
 	/* set TX and RX rings length */
 	stmmac_set_rings_length(priv);
@@ -3279,6 +3304,11 @@ static int stmmac_rx(struct stmmac_priv *priv, int limit, u32 queue)
 	int coe = priv->hw->rx_csum;
 	unsigned int next_entry;
 	unsigned int count = 0;
+
+#ifdef DEV_NETMAP
+	if (netmap_rx_irq(priv->dev, 0, &count))
+		return count;
+#endif /* DEV_NETMAP */
 
 	if (netif_msg_rx_status(priv)) {
 		void *rx_head;
@@ -4230,6 +4260,10 @@ int stmmac_dvr_probe(struct device *device,
 		goto error_netdev_register;
 	}
 
+#ifdef DEV_NETMAP
+	stmmac_netmap_attach(priv);
+#endif /* DEV_NETMAP */
+
 	return ret;
 
 error_netdev_register:
@@ -4276,6 +4310,11 @@ int stmmac_dvr_remove(struct device *dev)
 	    priv->hw->pcs != STMMAC_PCS_TBI &&
 	    priv->hw->pcs != STMMAC_PCS_RTBI)
 		stmmac_mdio_unregister(ndev);
+
+#ifdef DEV_NETMAP
+	netmap_detach(ndev);
+#endif /* DEV_NETMAP */
+
 	free_netdev(ndev);
 
 	return 0;
@@ -4495,8 +4534,8 @@ static void __exit stmmac_exit(void)
 #endif
 }
 
-module_init(stmmac_init)
-module_exit(stmmac_exit)
+module_init(stmmac_init);
+module_exit(stmmac_exit);
 
 MODULE_DESCRIPTION("STMMAC 10/100/1000 Ethernet device driver");
 MODULE_AUTHOR("Giuseppe Cavallaro <peppe.cavallaro@st.com>");


### PR DESCRIPTION
RFC
stmmac: add netmap entry point functions

1. add netmap call back functions, these function are defined in a header
based implementation 'netmap/LINUX/if_stmmac_netmap_linux.h', and

2. fix compiler warning when cross building the driver with:
arm-buildroot-linux-gnueabihf-gcc (Buildroot 2019.02.2-g0b3ebc6ca5-dirty) 8.3.0
